### PR TITLE
Add GoReleaser release pipeline

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
     branches: [master]
-    tags: ['v*']
+    tags: ['v*.*.*']
   pull_request:
     branches: [master]
 
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: cicd-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
   test:
@@ -26,9 +26,9 @@ jobs:
           - os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -43,16 +43,18 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           cache: true
 
       - name: gofmt
         run: |
-          unformatted=$(gofmt -l . 2>/dev/null | grep -v '^vendor/' || true)
+          set -euo pipefail
+          unformatted=$(gofmt -l .)
+          unformatted=$(printf '%s\n' "$unformatted" | grep -v '^vendor/' || true)
           if [ -n "$unformatted" ]; then
             echo "files need gofmt:" >&2
             echo "$unformatted" >&2
@@ -66,24 +68,36 @@ jobs:
     name: goreleaser config check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           cache: true
 
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@v7.0.0
         with:
           version: '~> v2.14'
           args: check
 
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: docker/setup-qemu-action@v4.0.0
+
+      - uses: docker/setup-buildx-action@v4.0.0
+
+      - uses: sigstore/cosign-installer@v4.1.1
+
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+          mkdir -p "$HOME/.cache/snapcraft/download"
+          mkdir -p "$HOME/.cache/snapcraft/stage-packages"
+
+      - uses: goreleaser/goreleaser-action@v7.0.0
         with:
           version: '~> v2.14'
-          args: build --snapshot --clean --single-target
+          args: release --snapshot --clean --skip=publish
 
   release:
     name: goreleaser
@@ -99,22 +113,22 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           cache: true
 
-      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-qemu-action@v4.0.0
 
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@v4.0.0
 
       - uses: sigstore/cosign-installer@v4.1.1
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -125,7 +139,7 @@ jobs:
           mkdir -p "$HOME/.cache/snapcraft/download"
           mkdir -p "$HOME/.cache/snapcraft/stage-packages"
 
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@v7.0.0
         with:
           version: '~> v2.14'
           args: release --clean

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,148 +2,135 @@ name: CI/CD
 
 on:
   push:
-    branches: ["master", "devel"]
-    tags: ["v*.*.*"]
+    branches: [master]
+    tags: ['v*']
   pull_request:
-    branches: ["master"]
+    branches: [master]
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: cicd-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    env:
-      GO111MODULE: on
-      APP_NAME: 'ignoreinit'
-      DEFAULT_BUILD_ARCH: 'amd64'
-
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-26
+          - os: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4.2.1
+      - uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v5.0.2
+      - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
+          cache: true
 
-      - name: Install dependencies
-        run: go get
+      - name: build
+        run: go build ./...
 
-      - name: Build
-        shell: pwsh
-        run: ./build.ps1
+      - name: test
+        run: go test -race ./...
 
-      - name: Create deb
-        if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')}}
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: gofmt
         run: |
-          REF=${{ github.ref_name }}
-          APP_VERSION=${REF//v/}
-          APP_ID=${{ env.APP_NAME }}_${APP_VERSION}_${{ env.DEFAULT_BUILD_ARCH }}
-          TMP_DIR=/tmp/$APP_ID
-          APP_DIR=$TMP_DIR/usr/local/bin
-          mkdir -p $APP_DIR
-          cp ./bin/${{ env.APP_NAME }}-${{ env.DEFAULT_BUILD_ARCH }}-linux $APP_DIR/${{ env.APP_NAME }}
-          mkdir $TMP_DIR/DEBIAN
-          
-          cat <<EOF > $TMP_DIR/DEBIAN/control
-          Package: ${{ env.APP_NAME }}
-          Version: $APP_VERSION
-          Architecture: ${{ env.DEFAULT_BUILD_ARCH }}
-          Maintainer: Dominik Zarsky <dzarsky@dzarsky.eu>
-          Description: A tool for creating .gitignore files from the command line.
-          EOF
-  
-          chmod +x $APP_DIR/${{ env.APP_NAME }}
-          dpkg-deb --build --root-owner-group $TMP_DIR
+          unformatted=$(gofmt -l . 2>/dev/null | grep -v '^vendor/' || true)
+          if [ -n "$unformatted" ]; then
+            echo "files need gofmt:" >&2
+            echo "$unformatted" >&2
+            exit 1
+          fi
 
-      - name: Publish artifact
-        if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')}}
-        uses: actions/upload-artifact@v4.4.3
-        with:
-          name: deb
-          path: /tmp/*.deb
+      - name: go vet
+        run: go vet ./...
 
-      - uses: actions/upload-artifact@v4.4.3
-        with:
-          name: artifact
-          path: ./bin/*
-
-  docker:
-    name: Docker
-    needs: build
-    if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')}}
+  goreleaser-check:
+    name: goreleaser config check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.1
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2.1.0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: '~> v2.14'
+          args: check
+
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: '~> v2.14'
+          args: build --snapshot --clean --single-target
+
+  release:
+    name: goreleaser
+    needs:
+      - test
+      - lint
+      - goreleaser-check
+    if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: sigstore/cosign-installer@v4.1.1
+
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v4.0.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            loupeznik/ignoreinit:${{ github.ref_name }}
-            loupeznik/ignoreinit:latest
+      - name: Install snapcraft
+        run: |
+          sudo snap install snapcraft --classic
+          mkdir -p "$HOME/.cache/snapcraft/download"
+          mkdir -p "$HOME/.cache/snapcraft/stage-packages"
 
-#  apt:
-#    name: APT release
-#    needs: build
-#    if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')}}
-#    runs-on: oc-ubuntu-4
-#    steps:
-#      - uses: actions/download-artifact@v4
-#        with:
-#          name: deb
-#          path: output
-#
-#      - name: Publish package
-#        run: |
-#            GPG_TTY=$(tty)
-#            export GPG_TTY
-#
-#            cd /opt/repo/apt
-#            cp /tmp/dist/*.deb amd64
-#
-#            dpkg-scanpackages --arch amd64 --multiversion . > Packages
-#            gzip -k -f Packages
-#
-#            apt-ftparchive release . > Release
-#
-#            echo ${{ secrets.GPG_KEY_PASSPHRASE }} > /tmp/gpg_secret
-#            chmod 600 /tmp/gpg_secret
-#            gpg --pinentry-mode loopback --passphrase-file "/tmp/gpg_secret" --yes -abs -u ${{ SECRETS.GPG_KEY_ID }} -o Release.gpg Release
-#            rm /tmp/gpg_secret
-#            rm -rf /tmp/dist
-  
-  release:
-    name: Release
-    needs:
-      - build
-      #- apt
-      - docker
-    if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/')}}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
+      - uses: goreleaser/goreleaser-action@v7
         with:
-          name: artifact
-          path: output
-
-      - name: Create a release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            output/**/*
-          generate_release_notes: true
-          name: "${{ github.ref_name }}"
+          version: '~> v2.14'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,149 @@
+version: 2
+
+project_name: ignoreinit
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: ignoreinit
+    main: .
+    binary: ignoreinit
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - '386'
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+
+archives:
+  - id: ignoreinit
+    ids:
+      - ignoreinit
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE
+      - README.md
+
+dockers_v2:
+  - id: ignoreinit
+    ids:
+      - ignoreinit
+    dockerfile: Dockerfile.goreleaser
+    images:
+      - docker.io/loupeznik/ignoreinit
+    tags:
+      - "{{ .Version }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.source: https://github.com/loupeznik/ignoreinit
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: A tool for creating .gitignore files from the command line
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .Commit }}"
+      org.opencontainers.image.created: "{{ .Date }}"
+      org.opencontainers.image.licenses: MIT
+    extra_files:
+      - LICENSE
+
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    args:
+      - sign
+      - --yes
+      - "${artifact}@${digest}"
+
+homebrew_casks:
+  - name: ignoreinit
+    ids:
+      - ignoreinit
+    binaries: [ignoreinit]
+    directory: Casks
+    repository:
+      owner: Loupeznik
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/Loupeznik/ignoreinit"
+    description: "A tool for creating .gitignore files from the command line"
+    license: "MIT"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ignoreinit"]
+          end
+    skip_upload: auto
+
+snapcrafts:
+  - id: ignoreinit
+    ids:
+      - ignoreinit
+    name: ignoreinit
+    title: ignoreinit
+    summary: A tool for creating .gitignore files from the command line
+    description: |
+      Ignoreinit is a tool for creating .gitignore files from the command line.
+      Gitignore files are pulled from the github/gitignore repository.
+    grade: '{{ if eq .Major 0 }}devel{{ else }}stable{{ end }}'
+    confinement: strict
+    license: MIT
+    publish: true
+    apps:
+      ignoreinit:
+        command: ignoreinit
+        plugs: [home, network]
+
+aurs:
+  - name: ignoreinit-bin
+    ids:
+      - ignoreinit
+    homepage: "https://github.com/Loupeznik/ignoreinit"
+    description: "A tool for creating .gitignore files from the command line"
+    maintainers:
+      - 'Dominik Zarsky <dzarsky@dzarsky.eu>'
+    license: "MIT"
+    private_key: "{{ .Env.AUR_KEY }}"
+    git_url: "ssh://aur@aur.archlinux.org/ignoreinit-bin.git"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    package: |-
+      install -Dm755 "./ignoreinit" "${pkgdir}/usr/bin/ignoreinit"
+      install -Dm644 "./LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,7 @@ project_name: ignoreinit
 
 before:
   hooks:
-    - go mod tidy
+    - sh -c 'go mod tidy && git diff --exit-code -- go.mod go.sum'
 
 builds:
   - id: ignoreinit
@@ -106,10 +106,15 @@ snapcrafts:
     confinement: strict
     license: MIT
     publish: true
+    plugs:
+      dot-gitignore:
+        interface: personal-files
+        write:
+          - $HOME/.gitignore
     apps:
       ignoreinit:
         command: ignoreinit
-        plugs: [home, network]
+        plugs: [home, network, dot-gitignore]
 
 aurs:
   - name: ignoreinit-bin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,9 +19,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: darwin
-        goarch: '386'
     ldflags:
       - -s -w
       - -X main.version={{ .Version }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      - '386'
     ignore:
       - goos: darwin
         goarch: '386'

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,6 @@
+FROM gcr.io/distroless/static-debian12
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/ignoreinit /usr/local/bin/ignoreinit
+COPY LICENSE /
+WORKDIR /work
+ENTRYPOINT ["/usr/local/bin/ignoreinit"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12:nonroot
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/ignoreinit /usr/local/bin/ignoreinit
 COPY LICENSE /

--- a/README.md
+++ b/README.md
@@ -61,20 +61,16 @@ docker run --rm -v $HOME/projects:/work loupeznik/ignoreinit:latest init go .
 sudo snap install ignoreinit
 ```
 
-### Install via apt
-
-On Debian-based distros, *ignoreinit* can be installed via *apt* using a custom *apt* repo. This option is currently supported for *amd64* systems.
+### Install via Homebrew
 
 ```bash
-sudo -s
+brew install --cask loupeznik/tap/ignoreinit
+```
 
-apt install -y curl gpg
+### Install via AUR
 
-curl -fsSL https://apt.dzarsky.eu/apt-repo-dzarsky.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/apt-repo-dzarsky.gpg
-echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/apt-repo-dzarsky.gpg] https://apt.dzarsky.eu /" > /etc/apt/sources.list.d/apt-repo-dzarsky.list
-
-apt update
-apt install ignoreinit
+```bash
+yay -S ignoreinit-bin
 ```
 
 ### Install via go

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"github.com/loupeznik/ignoreinit/src"
 )
 
-const version = "1.1.1"
+var version = "dev"
 
 func main() {
 	flags := src.Flags{}


### PR DESCRIPTION
## Summary
Replace the legacy CI/CD release flow with a GoReleaser-based pipeline for tagged releases.

## Changes
- Add GoReleaser configuration for GitHub releases, DockerHub images, Snapcraft, AUR, and the Homebrew tap.
- Add a GoReleaser Dockerfile for release image publishing.
- Replace the existing workflow with test, lint, GoReleaser config validation, and tag-driven release jobs.
- Switch the CLI version value to ldflags injection and update install docs for Homebrew/AUR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added installation support via Homebrew and AUR package managers.

* **Documentation**
  * Updated installation instructions with new package manager options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->